### PR TITLE
Improve GUI interactions for battle, shop, and healing

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -8,12 +8,8 @@ import time
 from main import (
     girls_data, elemental_multiplier, get_girl_stats, get_current_hp,
     is_available, get_current_time, save_game, load_save,
-    single_pull, ten_pull, show_inventory, show_dupes, turn_based_battle,
-    training, healing_session, check_scavenging_results, scavenging,
-    normal_victory_hook
+    GirlClass, monsters
 )
-from shop import show_shop
-from bosses import boss_menu
 
 # ----------------------------------------------------------------------
 # DARK BLUE + PINK THEME
@@ -65,17 +61,31 @@ class GachaApp:
         style.configure('Card.TFrame', background=BG_CARD, relief='flat', borderwidth=1)
 
         self.data = load_save()
-        self.funcs = {
-            "girls_data": girls_data,
-            "elemental_multiplier": elemental_multiplier,
-            "get_girl_stats": get_girl_stats,
-            "get_current_hp": get_current_hp,
-            "is_available": is_available,
-            "get_current_time": get_current_time,
-            "save_game": save_game,
-        }
-
+        self.ensure_boss_state()
+        self.resource_label = None
         self.create_main_menu()
+
+    def update_resources(self):
+        if self.resource_label is not None:
+            self.resource_label.configure(
+                text=f"Coins: {self.data['coins']} | Shards: {self.data['shards']}"
+            )
+
+    def ensure_boss_state(self):
+        self.data.setdefault("boss_defeat_counter", 0)
+        self.data.setdefault("cave_unlocked", False)
+        self.data.setdefault("active_boss", None)
+        self.data.setdefault("boss_fight_state", None)
+
+    def handle_normal_victory(self):
+        self.ensure_boss_state()
+        self.data["boss_defeat_counter"] += 1
+        if self.data["boss_defeat_counter"] >= 5 and not self.data["cave_unlocked"]:
+            self.data["cave_unlocked"] = True
+            messagebox.showinfo(
+                "Dark Cave Unlocked",
+                "Defeat 5 more monsters to open the next boss gate!"
+            )
 
     # ------------------------------------------------------------------
     # UTILS
@@ -140,8 +150,10 @@ class GachaApp:
 
         # === CONTENT ===
         ttk.Label(inner, text="GEMSTONE GACHA", font=("Segoe UI", 22, "bold"), foreground=ACCENT).pack(pady=12)
-        ttk.Label(inner, text=f"Coins: {self.data['coins']} | Shards: {self.data['shards']}",
-                  font=("Segoe UI", 11), foreground=TEXT_SUB).pack(pady=5)
+        self.resource_label = ttk.Label(inner,
+                                        text=f"Coins: {self.data['coins']} | Shards: {self.data['shards']}",
+                                        font=("Segoe UI", 11), foreground=TEXT_SUB)
+        self.resource_label.pack(pady=5)
 
         buttons = [
             ("Single Pull", self.single_pull),
@@ -366,19 +378,58 @@ class GachaApp:
     # BATTLE
     # ------------------------------------------------------------------
     def gui_battle(self):
-        import io
-        from contextlib import redirect_stdout
-        log = io.StringIO()
-        with redirect_stdout(log):
-            turn_based_battle(self.data)
-        win = self.open_window("Battle Log")
-        win.geometry("720x620")
+        available = [g for g, gd in self.data["inventory"].items() if is_available(gd)]
+        if not available:
+            messagebox.showinfo("Battle", "No girls available for battle!")
+            return
+
+        win = self.open_window("Battle")
+        win.geometry("780x640")
         win.configure(bg=BG_DARK)
-        text = scrolledtext.ScrolledText(win, wrap=tk.WORD, font=("Consolas", 10), bg=BG_CARD, fg=TEXT_FG)
-        text.pack(fill=tk.BOTH, expand=True, padx=12, pady=12)
-        text.insert(tk.END, log.getvalue())
-        text.config(state=tk.DISABLED)
-        ttk.Button(win, text="Close", command=win.destroy).pack(pady=8)
+
+        ttk.Label(win, text="Select up to 3 girls", foreground=TEXT_SUB).pack(pady=5)
+        listbox = tk.Listbox(win, selectmode=tk.MULTIPLE, bg=BG_CARD, fg=TEXT_FG,
+                             selectbackground=ACCENT, activestyle='dotbox')
+        for girl in available:
+            level = self.data["inventory"][girl]["level"]
+            elem = girls_data[girl]["element"]
+            cls = girls_data[girl]["class"]
+            listbox.insert(tk.END, f"{girl} (Lv.{level}) [{elem}/{cls}]")
+        listbox.pack(fill=tk.X, padx=12, pady=8)
+
+        ttk.Label(win, text="Choose a monster", foreground=TEXT_SUB).pack(pady=5)
+        monster_names = [m["name"] for m in monsters]
+        monster_var = tk.StringVar(value=monster_names[0])
+        monster_combo = ttk.Combobox(win, values=monster_names, textvariable=monster_var, state="readonly")
+        monster_combo.pack(padx=12, pady=5, fill=tk.X)
+
+        log = scrolledtext.ScrolledText(win, wrap=tk.WORD, font=("Consolas", 10), bg=BG_CARD, fg=TEXT_FG)
+        log.pack(fill=tk.BOTH, expand=True, padx=12, pady=12)
+        log.config(state=tk.DISABLED)
+
+        def start_battle():
+            selection = listbox.curselection()
+            if not selection:
+                messagebox.showerror("Battle", "Please select at least one girl.")
+                return
+            if len(selection) > 3:
+                messagebox.showerror("Battle", "You can only send up to 3 girls.")
+                return
+            chosen_girls = [available[i] for i in selection]
+            monster_name = monster_var.get()
+            monster_template = next((m for m in monsters if m["name"] == monster_name), None)
+            if not monster_template:
+                messagebox.showerror("Battle", "Invalid monster selection.")
+                return
+            log.configure(state=tk.NORMAL)
+            log.delete("1.0", tk.END)
+            battle_log = self.simulate_battle(chosen_girls, monster_template)
+            log.insert(tk.END, battle_log)
+            log.configure(state=tk.DISABLED)
+            self.update_resources()
+
+        ttk.Button(win, text="Start Battle", command=start_battle).pack(pady=8)
+        ttk.Button(win, text="Close", command=win.destroy).pack(pady=5)
 
     # ------------------------------------------------------------------
     # TRAINING
@@ -415,19 +466,82 @@ class GachaApp:
     # SHOP
     # ------------------------------------------------------------------
     def gui_shop(self):
-        import io
-        from contextlib import redirect_stdout, redirect_stderr
-        log = io.StringIO()
-        with redirect_stdout(log), redirect_stderr(log):
-            show_shop(self.data, girls_data, get_current_time, is_available, save_game, "gacha_save.json")
-        win = self.open_window("Shop Log")
-        win.geometry("700x500")
+        win = self.open_window("Coin Shop")
+        win.geometry("520x420")
         win.configure(bg=BG_DARK)
-        text = scrolledtext.ScrolledText(win, wrap=tk.WORD, bg=BG_CARD, fg=TEXT_FG)
-        text.pack(fill=tk.BOTH, expand=True, padx=12, pady=12)
-        text.insert(tk.END, log.getvalue())
-        text.config(state=tk.DISABLED)
-        ttk.Button(win, text="Close", command=win.destroy).pack(pady=5)
+
+        coins_var = tk.StringVar(value=f"Coins: {self.data['coins']}")
+        ttk.Label(win, textvariable=coins_var, foreground=TEXT_SUB).pack(pady=6)
+
+        ttk.Label(win, text="Food (Healing)", foreground=TEXT_FG, font=("Segoe UI", 11, "bold")).pack(pady=(10, 4))
+
+        def buy_healing_potion():
+            if self.data["coins"] < 200:
+                messagebox.showerror("Shop", "Not enough coins for a Healing Potion!")
+                return
+            recovering = [
+                (f"{girl} ({max(0, (600 - (get_current_time() - gd['recovery_start']))/60):.1f} min left)"
+                 if gd["recovery_start"] is not None else girl,
+                 girl)
+                for girl, gd in self.data["inventory"].items()
+                if gd["recovery_start"] is not None and not is_available(gd)
+            ]
+            if not recovering:
+                messagebox.showinfo("Shop", "No girls are currently recovering!")
+                return
+            choice = self.select_from_list("Healing Potion", "Select a girl to fully heal:", recovering)
+            if not choice:
+                return
+            gdata = self.data["inventory"][choice]
+            self.data["coins"] -= 200
+            gdata["recovery_start"] = None
+            gdata["hp_at_start"] = None
+            save_game(self.data)
+            coins_var.set(f"Coins: {self.data['coins']}")
+            self.update_resources()
+            messagebox.showinfo("Shop", f"{choice} has been fully healed!")
+
+        ttk.Button(win, text="Healing Potion - 200 coins", command=buy_healing_potion).pack(fill=tk.X, padx=20, pady=4)
+
+        ttk.Label(win, text="Weapons (Boosts)", foreground=TEXT_FG, font=("Segoe UI", 11, "bold")).pack(pady=(16, 4))
+
+        def buy_attack_boost():
+            if self.data["coins"] < 1000:
+                messagebox.showerror("Shop", "Not enough coins for an Attack Booster!")
+                return
+            girls_list = [(f"{girl} (Lv.{gd['level']})", girl) for girl, gd in self.data["inventory"].items()]
+            if not girls_list:
+                messagebox.showinfo("Shop", "You have no girls to boost!")
+                return
+            choice = self.select_from_list("Attack Booster", "Select a girl to boost attack:", girls_list)
+            if not choice:
+                return
+            self.data["coins"] -= 1000
+            gdata = self.data["inventory"][choice]
+            gdata["attack_bonus"] = gdata.get("attack_bonus", 0) + 5
+            save_game(self.data)
+            coins_var.set(f"Coins: {self.data['coins']}")
+            self.update_resources()
+            messagebox.showinfo("Shop", f"{choice}'s attack increased by 5!")
+
+        ttk.Button(win, text="Attack Booster - 1000 coins", command=buy_attack_boost).pack(fill=tk.X, padx=20, pady=4)
+
+        ttk.Label(win, text="Materials", foreground=TEXT_FG, font=("Segoe UI", 11, "bold")).pack(pady=(16, 4))
+
+        def buy_shard_bundle():
+            if self.data["coins"] < 2000:
+                messagebox.showerror("Shop", "Not enough coins for a Shard Bundle!")
+                return
+            self.data["coins"] -= 2000
+            self.data["shards"] += 10
+            save_game(self.data)
+            coins_var.set(f"Coins: {self.data['coins']}")
+            self.update_resources()
+            messagebox.showinfo("Shop", "Purchased 10 shards!")
+
+        ttk.Button(win, text="Shard Bundle - 2000 coins", command=buy_shard_bundle).pack(fill=tk.X, padx=20, pady=4)
+
+        ttk.Button(win, text="Close", command=win.destroy).pack(pady=18)
 
     # ------------------------------------------------------------------
     # SCAVENGING
@@ -460,25 +574,244 @@ class GachaApp:
     # HEALING
     # ------------------------------------------------------------------
     def gui_healing(self):
-        import io
-        from contextlib import redirect_stdout
-        log = io.StringIO()
-        with redirect_stdout(log):
-            healing_session(self.data)
+        recovering = [g for g, gd in self.data["inventory"].items() if gd["recovery_start"] is not None and not is_available(gd)]
+        if not recovering:
+            messagebox.showinfo("Healing Session", "No girls are currently recovering!")
+            return
+
+        healers = [g for g, gd in self.data["inventory"].items()
+                   if is_available(gd) and girls_data[g]["class"] == GirlClass.HEALER]
+        if not healers:
+            messagebox.showinfo("Healing Session", "No healers are available right now!")
+            return
+
         win = self.open_window("Healing Session")
-        win.geometry("600x400")
+        win.geometry("520x320")
         win.configure(bg=BG_DARK)
-        text = scrolledtext.ScrolledText(win, wrap=tk.WORD, bg=BG_CARD, fg=TEXT_FG)
-        text.pack(fill=tk.BOTH, expand=True, padx=12, pady=12)
-        text.insert(tk.END, log.getvalue())
-        text.config(state=tk.DISABLED)
-        ttk.Button(win, text="Close", command=win.destroy).pack(pady=5)
+
+        ttk.Label(win, text="Select recovering girl", foreground=TEXT_SUB).pack(pady=(12, 4))
+        target_var = tk.StringVar(value=recovering[0])
+        target_combo = ttk.Combobox(win, values=recovering, textvariable=target_var, state="readonly")
+        target_combo.pack(fill=tk.X, padx=20)
+
+        ttk.Label(win, text="Select healer", foreground=TEXT_SUB).pack(pady=(16, 4))
+        healer_var = tk.StringVar(value=healers[0])
+        healer_combo = ttk.Combobox(win, values=healers, textvariable=healer_var, state="readonly")
+        healer_combo.pack(fill=tk.X, padx=20)
+
+        def start_healing():
+            target = target_var.get()
+            healer = healer_var.get()
+            if not target or not healer:
+                messagebox.showerror("Healing Session", "Please select both a target and a healer.")
+                return
+            if target == healer:
+                messagebox.showerror("Healing Session", "A girl cannot heal herself.")
+                return
+            now = get_current_time()
+            fast_start = now - 420  # Jump ahead so only 3 minutes remain
+            target_data = self.data["inventory"][target]
+            healer_data = self.data["inventory"][healer]
+            if target_data.get("hp_at_start") is None:
+                target_stats = get_girl_stats(target, target_data["level"], self.data)
+                target_data["hp_at_start"] = target_stats["hp"]
+            if healer_data.get("hp_at_start") is None:
+                healer_stats = get_girl_stats(healer, healer_data["level"], self.data)
+                healer_data["hp_at_start"] = healer_stats["hp"]
+            target_data["recovery_start"] = fast_start
+            healer_data["recovery_start"] = fast_start
+            save_game(self.data)
+            messagebox.showinfo("Healing Session", f"{healer} is tending to {target}! They'll be back in ~3 minutes.")
+            win.destroy()
+            self.update_resources()
+
+        ttk.Button(win, text="Start Healing", command=start_healing).pack(pady=18)
+        ttk.Button(win, text="Close", command=win.destroy).pack()
 
     # ------------------------------------------------------------------
     # BOSS
     # ------------------------------------------------------------------
     def gui_boss(self):
-        boss_menu(self.data, self.funcs)
+        self.ensure_boss_state()
+
+        if not self.data.get("cave_unlocked"):
+            messagebox.showinfo("Dark Cave", "The cave is still sealed… Defeat more monsters to unlock it!")
+            return
+
+        win = self.open_window("Dark Cave")
+        win.geometry("520x300")
+        win.configure(bg=BG_DARK)
+
+        ttk.Label(win, text="The Dark Cave is open!", font=("Segoe UI", 14, "bold"), foreground=ACCENT).pack(pady=12)
+        ttk.Label(win,
+                  text=f"Bosses defeated: {self.data['boss_defeat_counter']}",
+                  foreground=TEXT_SUB).pack(pady=4)
+
+        if self.data.get("active_boss"):
+            boss = self.data["active_boss"]
+            ttk.Label(win, text=f"Active Boss: {boss['name']} ({boss['rarity']})",
+                      foreground=TEXT_FG).pack(pady=6)
+            ttk.Label(win, text="Resume boss fights from the command-line version.",
+                      foreground=TEXT_SUB).pack(pady=6)
+        else:
+            ttk.Label(win, text="Boss battles are not yet available in the GUI.",
+                      foreground=TEXT_SUB).pack(pady=12)
+            ttk.Label(win, text="Use the command-line mode for Dark Cave fights.",
+                      foreground=TEXT_SUB).pack(pady=4)
+
+        ttk.Button(win, text="Close", command=win.destroy).pack(pady=18)
+
+    def select_from_list(self, title, prompt, options):
+        """Display a modal selection dialog.
+
+        options should be a list of (label, value) pairs.
+        Returns the chosen value or None if cancelled.
+        """
+        if not options:
+            return None
+
+        dialog = tk.Toplevel(self.root)
+        dialog.title(title)
+        dialog.configure(bg=BG_DARK)
+        dialog.transient(self.root)
+        dialog.grab_set()
+
+        ttk.Label(dialog, text=prompt, wraplength=320, foreground=TEXT_FG).pack(pady=12, padx=12)
+
+        listbox = tk.Listbox(dialog, bg=BG_CARD, fg=TEXT_FG, selectbackground=ACCENT, activestyle='dotbox', height=min(10, len(options)))
+        for label, _ in options:
+            listbox.insert(tk.END, label)
+        listbox.pack(padx=12, pady=8, fill=tk.BOTH, expand=True)
+
+        result = {"value": None}
+
+        def confirm():
+            sel = listbox.curselection()
+            if not sel:
+                return
+            result["value"] = options[sel[0]][1]
+            dialog.destroy()
+
+        def cancel():
+            dialog.destroy()
+
+        ttk.Button(dialog, text="Select", command=confirm).pack(pady=(4, 2))
+        ttk.Button(dialog, text="Cancel", command=cancel).pack(pady=(0, 10))
+
+        dialog.wait_window()
+        return result["value"]
+
+    def simulate_battle(self, selected_girls, monster_template):
+        monster = monster_template.copy()
+        monster_max_hp = monster["hp"]
+        team = []
+        for girl in selected_girls:
+            gdata = self.data["inventory"][girl]
+            stats = get_girl_stats(girl, gdata["level"], self.data)
+            team.append({
+                "name": girl,
+                "stats": stats,
+                "hp": get_current_hp(girl, gdata, self.data),
+                "max_hp": stats["hp"],
+                "special_cd": 0,
+                "defending": False,
+                "shield": False,
+                "class": girls_data[girl]["class"],
+                "element": girls_data[girl]["element"]
+            })
+
+        log_lines = []
+        turn = 0
+        while monster["hp"] > 0 and any(g["hp"] > 0 for g in team):
+            turn += 1
+            log_lines.append(f"--- TURN {turn} ---")
+            log_lines.append(f"{monster['name']} HP: {int(monster['hp'])}/{monster_max_hp}")
+
+            for girl in team:
+                if girl["hp"] <= 0:
+                    continue
+                log_lines.append(f"{girl['name']} ({int(girl['hp'])}/{girl['max_hp']}) takes action")
+                action = self.choose_battle_action(girl, team)
+                if action == "basic":
+                    damage = max(1, girl["stats"]["attack"] - monster["defense"])
+                    monster["hp"] -= damage
+                    log_lines.append(f"  Basic attack deals {damage} damage")
+                elif action == "special":
+                    base = int(girl["stats"]["attack"] * 2.0)
+                    multi = elemental_multiplier(girl["element"], monster["element"])
+                    damage = max(1, int(base * multi) - monster["defense"])
+                    monster["hp"] -= damage
+                    girl["special_cd"] = 6
+                    if multi > 1:
+                        log_lines.append(f"  Special is super effective! {damage} damage")
+                    elif multi < 1:
+                        log_lines.append(f"  Special is not very effective… {damage} damage")
+                    else:
+                        log_lines.append(f"  Special deals {damage} damage")
+                elif action == "shield":
+                    for ally in team:
+                        if ally["hp"] > 0:
+                            ally["shield"] = True
+                    girl["special_cd"] = 6
+                    log_lines.append("  Casts a protective shield over the team")
+                else:  # defend
+                    girl["defending"] = True
+                    log_lines.append("  Braces for impact")
+
+                girl["special_cd"] = max(0, girl["special_cd"] - 1)
+                if monster["hp"] <= 0:
+                    break
+
+            if monster["hp"] <= 0:
+                break
+
+            log_lines.append("--- Monster Turn ---")
+            alive = [g for g in team if g["hp"] > 0]
+            if not alive:
+                break
+            target = random.choice(alive)
+            if target["defending"]:
+                log_lines.append(f"{monster['name']} attacks {target['name']} but the attack is blocked!")
+            elif target["shield"]:
+                log_lines.append(f"{monster['name']}'s attack is absorbed by {target['name']}'s shield!")
+                target["shield"] = False
+            else:
+                damage = max(1, monster["atk"] - target["stats"]["defense"])
+                target["hp"] -= damage
+                log_lines.append(f"{monster['name']} hits {target['name']} for {damage} damage ({int(max(0, target['hp']))} HP left)")
+            for girl in team:
+                girl["defending"] = False
+
+        if monster["hp"] <= 0:
+            log_lines.append("")
+            log_lines.append(f"{monster['name']} defeated! +{monster['shards']} shards")
+            self.data["shards"] += monster["shards"]
+            self.handle_normal_victory()
+        else:
+            log_lines.append("")
+            log_lines.append("The team was defeated…")
+
+        now = get_current_time()
+        for girl in selected_girls:
+            gdata = self.data["inventory"][girl]
+            final_hp = next((member["hp"] for member in team if member["name"] == girl), 1)
+            gdata["recovery_start"] = now
+            gdata["hp_at_start"] = max(1, int(final_hp))
+            log_lines.append(f"{girl} is recovering with {int(max(1, final_hp))} HP")
+
+        save_game(self.data)
+        return "\n".join(log_lines)
+
+    def choose_battle_action(self, girl, team):
+        if girl["class"] == GirlClass.HEALER and girl["special_cd"] == 0:
+            shields_active = all(ally["shield"] for ally in team if ally["hp"] > 0)
+            if not shields_active:
+                return "shield"
+        if girl["special_cd"] == 0:
+            return "special"
+        if girl["hp"] / girl["max_hp"] < 0.35:
+            return "defend"
+        return "basic"
 
 # ----------------------------------------------------------------------
 # LAUNCH


### PR DESCRIPTION
## Summary
- keep the main menu resource display in sync and track boss-unlock state in the GUI
- replace the battle, shop, and healing flows with native tkinter dialogs instead of redirecting CLI output
- surface dark cave status messaging in the GUI and add reusable list selection helpers

## Testing
- python -m compileall gui.py